### PR TITLE
Construção de um singleton para a centralização das configurações do ObjectMapper

### DIFF
--- a/src/main/java/inter/banking/extrato/ConsultarExtrato.java
+++ b/src/main/java/inter/banking/extrato/ConsultarExtrato.java
@@ -1,11 +1,11 @@
 package inter.banking.extrato;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.Extrato;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class ConsultarExtrato {
         String url = URL_BANKING_EXTRATO.replace("AMBIENTE", config.getAmbiente()) + "?dataInicio=" + dataInicial + "&dataFim=" + dataFinal;
         String json = HttpUtils.callGet(config, url, ESCOPO_EXTRATO_READ, "Erro ao consultar extrato");
         try {
-            return new ObjectMapper().readValue(json, Extrato.class);
+            return JsonUtils.read(json, Extrato.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/extrato/ConsultarExtratoEnriquecido.java
+++ b/src/main/java/inter/banking/extrato/ConsultarExtratoEnriquecido.java
@@ -1,6 +1,5 @@
 package inter.banking.extrato;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.PaginaExtratoEnriquecido;
 import inter.banking.model.FiltroConsultarExtratoEnriquecido;
 import inter.banking.model.TransacaoEnriquecida;
@@ -8,6 +7,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class ConsultarExtratoEnriquecido {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_EXTRATO_READ, "Erro ao consultar extrato enriquecido");
         try {
-            return new ObjectMapper().readValue(json, PaginaExtratoEnriquecido.class);
+            return JsonUtils.read(json, PaginaExtratoEnriquecido.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/extrato/RecuperarExtratoPdf.java
+++ b/src/main/java/inter/banking/extrato/RecuperarExtratoPdf.java
@@ -1,11 +1,11 @@
 package inter.banking.extrato;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.RetornoPdf;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.FileOutputStream;
@@ -25,7 +25,7 @@ public class RecuperarExtratoPdf {
         String url = URL_BANKING_EXTRATO_PDF.replace("AMBIENTE", config.getAmbiente()) + "?dataInicio=" + dataInicial + "&dataFim=" + dataFinal;
         String json = HttpUtils.callGet(config, url, ESCOPO_EXTRATO_READ, "Erro ao consultar extrato pdf");
         try {
-            RetornoPdf retornoPdf = new ObjectMapper().readValue(json, RetornoPdf.class);
+            RetornoPdf retornoPdf = JsonUtils.read(json, RetornoPdf.class);
             byte[] decodedBytes = Base64.getDecoder().decode(retornoPdf.getPdf());
             try (FileOutputStream stream = new FileOutputStream(arquivo)) {
                 stream.write(decodedBytes);

--- a/src/main/java/inter/banking/pagamento/BuscarLotePagamentos.java
+++ b/src/main/java/inter/banking/pagamento/BuscarLotePagamentos.java
@@ -9,6 +9,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -40,7 +41,7 @@ public class BuscarLotePagamentos {
             JSONObject jsonLote = (JSONObject) parser.parse(json);
             JSONArray jsonArray = (JSONArray) jsonLote.get("pagamentos");
             List<ItemLote> pagamentos = new ArrayList<>();
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = JsonUtils.getObjectMapper();
             if (jsonArray != null) {
                 for (JSONObject item : (Iterable<JSONObject>) jsonArray) {
                     String tipoPagamento = (String) item.get("tipoPagamento");
@@ -58,7 +59,7 @@ public class BuscarLotePagamentos {
             processamentoLote.setPagamentos(pagamentos);
             return processamentoLote;
             //]
-            //=return new ObjectMapper().readValue(json, ProcessamentoLote.class);
+            //=return JsonUtils.read(json, ProcessamentoLote.class);
         } catch (IOException | ParseException e) {
             log.error(GENERIC_EXCEPTION_MESSAGE, e);
             throw new SdkException(

--- a/src/main/java/inter/banking/pagamento/BuscarPagamentos.java
+++ b/src/main/java/inter/banking/pagamento/BuscarPagamentos.java
@@ -1,13 +1,13 @@
 package inter.banking.pagamento;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.FiltroBuscarPagamentos;
 import inter.banking.model.Pagamento;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ public class BuscarPagamentos {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PAGAMENTO_BOLETO_READ, "Erro ao buscar pagamentos");
         try {
-            return new ObjectMapper().readValue(json, new TypeReference<List<Pagamento>>() {
+            return JsonUtils.read(json, new TypeReference<List<Pagamento>>() {
             });
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/banking/pagamento/BuscarPagamentosDarf.java
+++ b/src/main/java/inter/banking/pagamento/BuscarPagamentosDarf.java
@@ -1,13 +1,13 @@
 package inter.banking.pagamento;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.FiltroBuscarPagamentosDarf;
 import inter.banking.model.RetornoPagamentoDarf;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ public class BuscarPagamentosDarf {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PAGAMENTO_BOLETO_READ, "Erro ao buscar pagamentos de DARF");
         try {
-            return new ObjectMapper().readValue(json, new TypeReference<List<RetornoPagamentoDarf>>() {
+            return JsonUtils.read(json, new TypeReference<List<RetornoPagamentoDarf>>() {
             });
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/banking/pagamento/IncluirPagamento.java
+++ b/src/main/java/inter/banking/pagamento/IncluirPagamento.java
@@ -1,12 +1,12 @@
 package inter.banking.pagamento;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.PagamentoBoleto;
 import inter.banking.model.RespostaIncluirPagamento;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class IncluirPagamento {
         log.info("IncluirPagamento {} {}", config.getClientId(), pagamento.getCodBarraLinhaDigitavel());
         String url = URL_BANKING_PAGAMENTO.replace("AMBIENTE", config.getAmbiente());
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(pagamento);
+            String json = JsonUtils.writePretty(pagamento);
             json = HttpUtils.callPost(config, url, ESCOPO_PAGAMENTO_BOLETO_WRITE, "Erro ao incluir pagamento", json);
-            return new ObjectMapper().readValue(json, RespostaIncluirPagamento.class);
+            return JsonUtils.read(json, RespostaIncluirPagamento.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/pagamento/IncluirPagamentoDarf.java
+++ b/src/main/java/inter/banking/pagamento/IncluirPagamentoDarf.java
@@ -1,12 +1,12 @@
 package inter.banking.pagamento;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.PagamentoDarf;
 import inter.banking.model.RespostaIncluirPagamentoDarf;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class IncluirPagamentoDarf {
         log.info("IncluirPagamentoDarf {} {}", config.getClientId(), pagamento.getCodigoReceita());
         String url = URL_BANKING_PAGAMENTO_DARF.replace("AMBIENTE", config.getAmbiente());
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(pagamento);
+            String json = JsonUtils.writePretty(pagamento);
             json = HttpUtils.callPost(config, url, ESCOPO_PAGAMENTO_DARF_WRITE, "Erro ao incluir pagamento de darf", json);
-            return new ObjectMapper().readValue(json, RespostaIncluirPagamentoDarf.class);
+            return JsonUtils.read(json, RespostaIncluirPagamentoDarf.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/pagamento/IncluirPagamentosLote.java
+++ b/src/main/java/inter/banking/pagamento/IncluirPagamentosLote.java
@@ -1,6 +1,5 @@
 package inter.banking.pagamento;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.ItemLote;
 import inter.banking.model.Lote;
 import inter.banking.model.RespostaIncluirPagamentosLote;
@@ -8,6 +7,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -29,9 +29,9 @@ public class IncluirPagamentosLote {
                 .pagamentos(pagamentos)
                 .build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             json = HttpUtils.callPost(config, url, ESCOPO_PAGAMENTOS_LOTE_WRITE, "Erro ao incluir pagamentos em lote", json);
-            return new ObjectMapper().readValue(json, RespostaIncluirPagamentosLote.class);
+            return JsonUtils.read(json, RespostaIncluirPagamentosLote.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/pix/IncluirPix.java
+++ b/src/main/java/inter/banking/pix/IncluirPix.java
@@ -1,12 +1,12 @@
 package inter.banking.pix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.Pix;
 import inter.banking.model.RespostaIncluirPix;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class IncluirPix {
         log.info("IncluirPix {} {}", config.getClientId(), pix.getDescricao());
         String url = URL_BANKING_PAGAMENTO_PIX.replace("AMBIENTE", config.getAmbiente());
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(pix);
+            String json = JsonUtils.writePretty(pix);
             json = HttpUtils.callPost(config, url, ESCOPO_PAGAMENTO_PIX_WRITE, "Erro ao incluir pix", json);
-            return new ObjectMapper().readValue(json, RespostaIncluirPix.class);
+            return JsonUtils.read(json, RespostaIncluirPix.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/saldo/ConsultarSaldo.java
+++ b/src/main/java/inter/banking/saldo/ConsultarSaldo.java
@@ -1,11 +1,11 @@
 package inter.banking.saldo;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.Saldo;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -26,7 +26,7 @@ public class ConsultarSaldo {
         }
         String json = HttpUtils.callGet(config, url, ESCOPO_EXTRATO_READ, "Erro ao consultar saldo");
         try {
-            return new ObjectMapper().readValue(json, Saldo.class);
+            return JsonUtils.read(json, Saldo.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/webhook/ConsultarCallbacks.java
+++ b/src/main/java/inter/banking/webhook/ConsultarCallbacks.java
@@ -1,6 +1,5 @@
 package inter.banking.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.banking.model.FiltroBuscarCallbacks;
 import inter.banking.model.PaginaCallbacks;
 import inter.banking.model.RespostaBuscarCallbacks;
@@ -8,6 +7,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -52,7 +52,7 @@ public class ConsultarCallbacks {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_BANKING_WEBHOOK_BANKING_READ, "Erro ao recuperar callbacks");
         try {
-            return new ObjectMapper().readValue(json, PaginaCallbacks.class);
+            return JsonUtils.read(json, PaginaCallbacks.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/banking/webhook/CriarWebhook.java
+++ b/src/main/java/inter/banking/webhook/CriarWebhook.java
@@ -1,11 +1,11 @@
 package inter.banking.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.CriarWebhookRequest;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -20,7 +20,7 @@ public class CriarWebhook {
         String url = URL_BANKING_WEBHOOK.replace("AMBIENTE", config.getAmbiente()) + "/" + tipoWebhook;
         CriarWebhookRequest request = CriarWebhookRequest.builder().webhookUrl(webhookUrl).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             HttpUtils.callPut(config, url, ESCOPO_BANKING_WEBHOOK_BANKING_WRITE, "Erro ao criar webhook", json);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/banking/webhook/ObterWebhook.java
+++ b/src/main/java/inter/banking/webhook/ObterWebhook.java
@@ -1,11 +1,11 @@
 package inter.banking.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.Webhook;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -20,7 +20,7 @@ public class ObterWebhook {
         String url = URL_BANKING_WEBHOOK.replace("AMBIENTE", config.getAmbiente()) + "/" + tipoWebhook;
         String json = HttpUtils.callGet(config, url, ESCOPO_BANKING_WEBHOOK_BANKING_READ, "Erro ao obter webhook");
         try {
-            return new ObjectMapper().readValue(json, Webhook.class);
+            return JsonUtils.read(json, Webhook.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobranca/boletos/CancelarBoleto.java
+++ b/src/main/java/inter/cobranca/boletos/CancelarBoleto.java
@@ -1,12 +1,12 @@
 package inter.cobranca.boletos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobranca.model.RequisicaoCancelarBoleto;
 import inter.cobranca.model.enums.MotivoCancelamento;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -24,7 +24,7 @@ public class CancelarBoleto {
         String url = URL_BOLETOS.replace("AMBIENTE", config.getAmbiente()) + "/" + nossoNumero + "/cancelar";
         RequisicaoCancelarBoleto request = RequisicaoCancelarBoleto.builder().motivoCancelamento(motivoCancelamento).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             HttpUtils.callPost(config, url, ESCOPO_BOLETO_COBRANCA_WRITE, "Erro ao cancelar boleto", json);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/cobranca/boletos/EmitirBoleto.java
+++ b/src/main/java/inter/cobranca/boletos/EmitirBoleto.java
@@ -1,12 +1,12 @@
 package inter.cobranca.boletos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobranca.model.Boleto;
 import inter.cobranca.model.RespostaEmitirBoleto;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class EmitirBoleto {
         log.info("EmitirBoleto {} {}", config.getClientId(), boleto.getSeuNumero());
         String url = URL_BOLETOS.replace("AMBIENTE", config.getAmbiente());
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(boleto);
+            String json = JsonUtils.writePretty(boleto);
             json = HttpUtils.callPost(config, url, ESCOPO_BOLETO_COBRANCA_WRITE, "Erro ao emitir boleto", json);
-            return new ObjectMapper().readValue(json, RespostaEmitirBoleto.class);
+            return JsonUtils.read(json, RespostaEmitirBoleto.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobranca/boletos/RecuperarBoletoDetalhado.java
+++ b/src/main/java/inter/cobranca/boletos/RecuperarBoletoDetalhado.java
@@ -1,11 +1,11 @@
 package inter.cobranca.boletos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobranca.model.BoletoDetalhado;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class RecuperarBoletoDetalhado {
         String url = URL_BOLETOS.replace("AMBIENTE", config.getAmbiente()) + "/" + nossoNumero;
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar boleto detalhado");
         try {
-            return new ObjectMapper().readValue(json, BoletoDetalhado.class);
+            return JsonUtils.read(json, BoletoDetalhado.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobranca/boletos/RecuperarBoletoPdf.java
+++ b/src/main/java/inter/cobranca/boletos/RecuperarBoletoPdf.java
@@ -1,11 +1,11 @@
 package inter.cobranca.boletos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.RetornoPdf;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.FileOutputStream;
@@ -25,7 +25,7 @@ public class RecuperarBoletoPdf {
         String url = URL_BOLETOS.replace("AMBIENTE", config.getAmbiente()) + "/" + nossoNumero + "/pdf";
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar boleto pdf");
         try {
-            RetornoPdf retornoPdf = new ObjectMapper().readValue(json, RetornoPdf.class);
+            RetornoPdf retornoPdf = JsonUtils.read(json, RetornoPdf.class);
             byte[] decodedBytes = Base64.getDecoder().decode(retornoPdf.getPdf());
             try (FileOutputStream stream = new FileOutputStream(arquivo)) {
                 stream.write(decodedBytes);

--- a/src/main/java/inter/cobranca/boletos/RecuperarBoletos.java
+++ b/src/main/java/inter/cobranca/boletos/RecuperarBoletos.java
@@ -1,6 +1,5 @@
 package inter.cobranca.boletos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobranca.model.BoletoDetalhado;
 import inter.cobranca.model.FiltroRecuperarBoletos;
 import inter.cobranca.model.Ordenacao;
@@ -9,6 +8,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ public class RecuperarBoletos {
                 + addSort(ordenacao);
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar boletos");
         try {
-            return new ObjectMapper().readValue(json, PaginaBoletos.class);
+            return JsonUtils.read(json, PaginaBoletos.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobranca/boletos/RecuperarSumarioBoletos.java
+++ b/src/main/java/inter/cobranca/boletos/RecuperarSumarioBoletos.java
@@ -1,12 +1,12 @@
 package inter.cobranca.boletos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobranca.model.FiltroRecuperarSumarioBoletos;
 import inter.cobranca.model.Sumario;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -25,7 +25,7 @@ public class RecuperarSumarioBoletos {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar sumário de boletos");
         try {
-            return new ObjectMapper().readValue(json, Sumario.class);
+            return JsonUtils.read(json, Sumario.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobranca/webhook/ConsultarCallbacks.java
+++ b/src/main/java/inter/cobranca/webhook/ConsultarCallbacks.java
@@ -1,6 +1,5 @@
 package inter.cobranca.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobranca.model.FiltroBuscarCallbacks;
 import inter.cobranca.model.PaginaCallbacks;
 import inter.cobranca.model.RespostaBuscarCallbacks;
@@ -8,6 +7,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -50,7 +50,7 @@ public class ConsultarCallbacks {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar callbacks");
         try {
-            return new ObjectMapper().readValue(json, PaginaCallbacks.class);
+            return JsonUtils.read(json, PaginaCallbacks.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobranca/webhook/CriarWebhook.java
+++ b/src/main/java/inter/cobranca/webhook/CriarWebhook.java
@@ -1,11 +1,11 @@
 package inter.cobranca.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.CriarWebhookRequest;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class CriarWebhook {
         String url = URL_BOLETOS_WEBHOOK.replace("AMBIENTE", config.getAmbiente());
         CriarWebhookRequest request = CriarWebhookRequest.builder().webhookUrl(webhookUrl).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             HttpUtils.callPut(config, url, ESCOPO_BOLETO_COBRANCA_WRITE, "Erro ao criar webhook", json);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/cobranca/webhook/ObterWebhook.java
+++ b/src/main/java/inter/cobranca/webhook/ObterWebhook.java
@@ -1,11 +1,11 @@
 package inter.cobranca.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.Webhook;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class ObterWebhook {
         String url = URL_BOLETOS_WEBHOOK.replace("AMBIENTE", config.getAmbiente());
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao obter webhook");
         try {
-            return new ObjectMapper().readValue(json, Webhook.class);
+            return JsonUtils.read(json, Webhook.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobrancav3/cobranca/CancelaCobranca.java
+++ b/src/main/java/inter/cobrancav3/cobranca/CancelaCobranca.java
@@ -1,11 +1,11 @@
 package inter.cobrancav3.cobranca;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobrancav3.model.RequisicaoCancelarCobranca;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class CancelaCobranca {
         String url = URL_COBRANCAS.replace("AMBIENTE", config.getAmbiente()) + "/" + codigoSolicitacao + "/cancelar";
         RequisicaoCancelarCobranca request = RequisicaoCancelarCobranca.builder().motivoCancelamento(motivoCancelamento).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             HttpUtils.callPost(config, url, ESCOPO_BOLETO_COBRANCA_WRITE, "Erro ao cancelar cobranca", json);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/cobrancav3/cobranca/EmiteCobranca.java
+++ b/src/main/java/inter/cobrancav3/cobranca/EmiteCobranca.java
@@ -1,12 +1,12 @@
 package inter.cobrancav3.cobranca;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobrancav3.model.RequisicaoEmitirCobranca;
 import inter.cobrancav3.model.RespostaEmitirCobranca;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class EmiteCobranca {
         log.info("EmitirCobranca {} {}", config.getClientId(), requisicaoEmitirCobranca.getSeuNumero());
         String url = URL_COBRANCAS.replace("AMBIENTE", config.getAmbiente());
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(requisicaoEmitirCobranca);
+            String json = JsonUtils.writePretty(requisicaoEmitirCobranca);
             json = HttpUtils.callPost(config, url, ESCOPO_BOLETO_COBRANCA_WRITE, "Erro ao emitir cobrança", json);
-            return new ObjectMapper().readValue(json, RespostaEmitirCobranca.class);
+            return JsonUtils.read(json, RespostaEmitirCobranca.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobrancav3/cobranca/RecuperaCobranca.java
+++ b/src/main/java/inter/cobrancav3/cobranca/RecuperaCobranca.java
@@ -1,11 +1,11 @@
 package inter.cobrancav3.cobranca;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobrancav3.model.CobrancaRecuperada;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class RecuperaCobranca {
         String url = URL_COBRANCAS.replace("AMBIENTE", config.getAmbiente()) + "/" + codigoSolicitacao;
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar cobrança");
         try {
-            return new ObjectMapper().readValue(json, CobrancaRecuperada.class);
+            return JsonUtils.read(json, CobrancaRecuperada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobrancav3/cobranca/RecuperaCobrancaPdf.java
+++ b/src/main/java/inter/cobrancav3/cobranca/RecuperaCobrancaPdf.java
@@ -1,11 +1,11 @@
 package inter.cobrancav3.cobranca;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.RetornoPdf;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.FileOutputStream;
@@ -25,7 +25,7 @@ public class RecuperaCobrancaPdf {
         String url = URL_COBRANCAS.replace("AMBIENTE", config.getAmbiente()) + "/" + codigoSolicitacao + "/pdf";
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar cobrança pdf");
         try {
-            RetornoPdf retornoPdf = new ObjectMapper().readValue(json, RetornoPdf.class);
+            RetornoPdf retornoPdf = JsonUtils.read(json, RetornoPdf.class);
             byte[] decodedBytes = Base64.getDecoder().decode(retornoPdf.getPdf());
             try (FileOutputStream stream = new FileOutputStream(arquivo)) {
                 stream.write(decodedBytes);

--- a/src/main/java/inter/cobrancav3/cobranca/RecuperaColecaoCobrancas.java
+++ b/src/main/java/inter/cobrancav3/cobranca/RecuperaColecaoCobrancas.java
@@ -1,7 +1,5 @@
 package inter.cobrancav3.cobranca;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import inter.cobrancav3.model.FiltroRecuperarCobrancas;
 import inter.cobrancav3.model.Ordenacao;
 import inter.cobrancav3.model.PaginaCobrancas;
@@ -10,6 +8,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -52,7 +51,7 @@ public class RecuperaColecaoCobrancas {
                 + addSort(ordenacao);
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar cobranças");
         try {
-            return new ObjectMapper().readValue(json, PaginaCobrancas.class);
+            return JsonUtils.read(json, PaginaCobrancas.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobrancav3/cobranca/RecuperaSumarioCobrancas.java
+++ b/src/main/java/inter/cobrancav3/cobranca/RecuperaSumarioCobrancas.java
@@ -1,12 +1,12 @@
 package inter.cobrancav3.cobranca;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobrancav3.model.FiltroRecuperarSumarioCobrancas;
 import inter.cobrancav3.model.Sumario;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -25,7 +25,7 @@ public class RecuperaSumarioCobrancas {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar sumário de cobrancas");
         try {
-            return new ObjectMapper().readValue(json, Sumario.class);
+            return JsonUtils.read(json, Sumario.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobrancav3/webhook/ConsultaCallbacks.java
+++ b/src/main/java/inter/cobrancav3/webhook/ConsultaCallbacks.java
@@ -1,6 +1,5 @@
 package inter.cobrancav3.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.cobrancav3.model.FiltroBuscarCallbacks;
 import inter.cobrancav3.model.PaginaCallbacks;
 import inter.cobrancav3.model.RespostaBuscarCallbacks;
@@ -8,6 +7,7 @@ import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -50,7 +50,7 @@ public class ConsultaCallbacks {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao recuperar callbacks");
         try {
-            return new ObjectMapper().readValue(json, PaginaCallbacks.class);
+            return JsonUtils.read(json, PaginaCallbacks.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/cobrancav3/webhook/CriaWebhook.java
+++ b/src/main/java/inter/cobrancav3/webhook/CriaWebhook.java
@@ -1,11 +1,11 @@
 package inter.cobrancav3.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.CriarWebhookRequest;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class CriaWebhook {
         String url = URL_COBRANCAS_WEBHOOK.replace("AMBIENTE", config.getAmbiente());
         CriarWebhookRequest request = CriarWebhookRequest.builder().webhookUrl(webhookUrl).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             HttpUtils.callPut(config, url, ESCOPO_BOLETO_COBRANCA_WRITE, "Erro ao criar webhook", json);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/cobrancav3/webhook/ObtemWebhook.java
+++ b/src/main/java/inter/cobrancav3/webhook/ObtemWebhook.java
@@ -1,11 +1,11 @@
 package inter.cobrancav3.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.Webhook;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class ObtemWebhook {
         String url = URL_COBRANCAS_WEBHOOK.replace("AMBIENTE", config.getAmbiente());
         String json = HttpUtils.callGet(config, url, ESCOPO_BOLETO_COBRANCA_READ, "Erro ao obter webhook");
         try {
-            return new ObjectMapper().readValue(json, Webhook.class);
+            return JsonUtils.read(json, Webhook.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/oauth/ObterToken.java
+++ b/src/main/java/inter/oauth/ObterToken.java
@@ -1,10 +1,10 @@
 package inter.oauth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.RespostaObterToken;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import inter.utils.SslUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
@@ -51,7 +51,7 @@ public class ObterToken {
         HttpUtils.handleResponse(url, response, "Erro ao obter token", config.isControleRateLimit());
         HttpEntity body = response.getEntity();
         String json = EntityUtils.toString(body, "UTF-8");
-        RespostaObterToken respostaToken = new ObjectMapper().readValue(json, RespostaObterToken.class);
+        RespostaObterToken respostaToken = JsonUtils.read(json, RespostaObterToken.class);
         respostaToken.setCreatedAt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
         return respostaToken;
     }

--- a/src/main/java/inter/pix/cob/ConsultarCobrancaImediata.java
+++ b/src/main/java/inter/pix/cob/ConsultarCobrancaImediata.java
@@ -1,11 +1,11 @@
 package inter.pix.cob;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.CobrancaDetalhada;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class ConsultarCobrancaImediata {
         String url = URL_PIX_COBRANCAS_IMEDIATAS.replace("AMBIENTE", config.getAmbiente()) + "/" + txId;
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_COB_READ, "Erro ao consultar cobrança imediata");
         try {
-            return new ObjectMapper().readValue(json, CobrancaDetalhada.class);
+            return JsonUtils.read(json, CobrancaDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cob/ConsultarCobrancasImediatas.java
+++ b/src/main/java/inter/pix/cob/ConsultarCobrancasImediatas.java
@@ -1,6 +1,5 @@
 package inter.pix.cob;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
@@ -8,6 +7,7 @@ import inter.pix.model.CobrancaDetalhada;
 import inter.pix.model.FiltroConsultarCobrancasImediatas;
 import inter.pix.model.PaginaCobrancas;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class ConsultarCobrancasImediatas {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_COB_READ, "Erro ao consultar cobranças imediatas");
         try {
-            return new ObjectMapper().readValue(json, PaginaCobrancas.class);
+            return JsonUtils.read(json, PaginaCobrancas.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cob/CriarCobrancaImediata.java
+++ b/src/main/java/inter/pix/cob/CriarCobrancaImediata.java
@@ -1,12 +1,12 @@
 package inter.pix.cob;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.Cobranca;
 import inter.pix.model.CobrancaDetalhada;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,14 +22,14 @@ public class CriarCobrancaImediata {
         log.info("CriarCobrancaImediata {} {}", config.getClientId(), cobranca.getTxid());
         String url = URL_PIX_COBRANCAS_IMEDIATAS.replace("AMBIENTE", config.getAmbiente());
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(cobranca);
+            String json = JsonUtils.writePretty(cobranca);
             if (cobranca.getTxid() == null) {
                 json = HttpUtils.callPost(config, url, ESCOPO_PIX_COB_WRITE, "Erro ao criar cobrança imediata", json);
             } else {
                 url += "/" + cobranca.getTxid();
                 json = HttpUtils.callPut(config, url, ESCOPO_PIX_COB_WRITE, "Erro ao criar cobrança imediata", json);
             }
-            return new ObjectMapper().readValue(json, CobrancaDetalhada.class);
+            return JsonUtils.read(json, CobrancaDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cob/RevisarCobrancaImediata.java
+++ b/src/main/java/inter/pix/cob/RevisarCobrancaImediata.java
@@ -1,12 +1,12 @@
 package inter.pix.cob;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.Cobranca;
 import inter.pix.model.CobrancaDetalhada;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,9 +22,9 @@ public class RevisarCobrancaImediata {
         log.info("RevisarCobrancaImediata {} {}", config.getClientId(), cobranca.getTxid());
         try {
             String url = URL_PIX_COBRANCAS_IMEDIATAS.replace("AMBIENTE", config.getAmbiente()) + "/" + cobranca.getTxid();
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(cobranca);
+            String json = JsonUtils.writePretty(cobranca);
             json = HttpUtils.callPatch(config, url, ESCOPO_PIX_COB_WRITE, "Erro ao revisar cobrança imediata", json);
-            return new ObjectMapper().readValue(json, CobrancaDetalhada.class);
+            return JsonUtils.read(json, CobrancaDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cobv/ConsultarCobrancaComVencimento.java
+++ b/src/main/java/inter/pix/cobv/ConsultarCobrancaComVencimento.java
@@ -1,11 +1,11 @@
 package inter.pix.cobv;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.pix.model.CobrancaVencimentoDetalhada;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ public class ConsultarCobrancaComVencimento {
         String url = URL_PIX_COBRANCA_COM_VENCIMENTO.replace("AMBIENTE", config.getAmbiente()) + "/" + txId;
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_COBV_READ, "Erro ao consultar cobrança com vencimento");
         try {
-            return new ObjectMapper().readValue(json, CobrancaVencimentoDetalhada.class);
+            return JsonUtils.read(json, CobrancaVencimentoDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cobv/ConsultarCobrancasComVencimento.java
+++ b/src/main/java/inter/pix/cobv/ConsultarCobrancasComVencimento.java
@@ -1,6 +1,5 @@
 package inter.pix.cobv;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.pix.model.CobrancaVencimentoDetalhada;
 import inter.pix.model.PaginaCobrancasVencimento;
 import inter.exceptions.SdkException;
@@ -9,6 +8,7 @@ import inter.model.Erro;
 
 import inter.pix.model.FiltroConsultarCobrancasComVencimento;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -48,7 +48,7 @@ public class ConsultarCobrancasComVencimento {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_COBV_READ, "Erro ao consultar cobranças imediatas");
         try {
-            return new ObjectMapper().readValue(json, PaginaCobrancasVencimento.class);
+            return JsonUtils.read(json, PaginaCobrancasVencimento.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cobv/CriarCobrancaComVencimento.java
+++ b/src/main/java/inter/pix/cobv/CriarCobrancaComVencimento.java
@@ -1,12 +1,12 @@
 package inter.pix.cobv;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.pix.model.CobrancaVencimento;
 import inter.pix.model.CobrancaVencimentoDetalhada;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class CriarCobrancaComVencimento {
         log.info("CriarCobrancaComVencimento {} {}", config.getClientId(), txid);
         String url = URL_PIX_COBRANCA_COM_VENCIMENTO.replace("AMBIENTE", config.getAmbiente()) + "/" + txid;
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(cobranca);
+            String json = JsonUtils.writePretty(cobranca);
             json = HttpUtils.callPut(config, url, ESCOPO_PIX_COBV_WRITE, "Erro ao criar cobrança com vencimento", json);
-            return new ObjectMapper().readValue(json, CobrancaVencimentoDetalhada.class);
+            return JsonUtils.read(json, CobrancaVencimentoDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/cobv/RevisarCobrancaComVencimento.java
+++ b/src/main/java/inter/pix/cobv/RevisarCobrancaComVencimento.java
@@ -1,12 +1,12 @@
 package inter.pix.cobv;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.pix.model.CobrancaVencimento;
 import inter.pix.model.CobrancaVencimentoDetalhada;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -23,9 +23,9 @@ public class RevisarCobrancaComVencimento {
         log.info("RevisarCobrancaImediata {} {}", config.getClientId(), txid);
         try {
             String url = URL_PIX_COBRANCA_COM_VENCIMENTO.replace("AMBIENTE", config.getAmbiente()) + "/" + txid;
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(cobranca);
+            String json = JsonUtils.writePretty(cobranca);
             json = HttpUtils.callPatch(config, url, ESCOPO_PIX_COBV_WRITE, "Erro ao revisar cobrança com vencimento", json);
-            return new ObjectMapper().readValue(json, CobrancaVencimentoDetalhada.class);
+            return JsonUtils.read(json, CobrancaVencimentoDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/location/ConsultarLocationsCadastradas.java
+++ b/src/main/java/inter/pix/location/ConsultarLocationsCadastradas.java
@@ -1,6 +1,5 @@
 package inter.pix.location;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
@@ -8,6 +7,7 @@ import inter.pix.model.FiltroConsultarLocations;
 import inter.pix.model.Location;
 import inter.pix.model.PaginaLocations;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class ConsultarLocationsCadastradas {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_LOCATION_READ, "Erro ao consultar locations");
         try {
-            return new ObjectMapper().readValue(json, PaginaLocations.class);
+            return JsonUtils.read(json, PaginaLocations.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/location/CriarLocation.java
+++ b/src/main/java/inter/pix/location/CriarLocation.java
@@ -1,6 +1,5 @@
 package inter.pix.location;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
@@ -8,6 +7,7 @@ import inter.pix.model.CriarLocationRequest;
 import inter.pix.model.Location;
 import inter.pix.model.enums.TipoCob;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -24,9 +24,9 @@ public class CriarLocation {
         String url = URL_PIX_LOCATIONS.replace("AMBIENTE", config.getAmbiente());
         CriarLocationRequest request = CriarLocationRequest.builder().tipoCob(tipoCob).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             json = HttpUtils.callPost(config, url, ESCOPO_PIX_LOCATION_WRITE, "Erro ao criar location", json);
-            return new ObjectMapper().readValue(json, Location.class);
+            return JsonUtils.read(json, Location.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/location/DesvincularLocation.java
+++ b/src/main/java/inter/pix/location/DesvincularLocation.java
@@ -1,11 +1,11 @@
 package inter.pix.location;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.Location;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class DesvincularLocation {
         String url = URL_PIX_LOCATIONS.replace("AMBIENTE", config.getAmbiente()) + "/" + id + "/txid";
         String json = HttpUtils.callDelete(config, url, ESCOPO_PIX_LOCATION_WRITE, "Erro ao desvincular location");
         try {
-            return new ObjectMapper().readValue(json, Location.class);
+            return JsonUtils.read(json, Location.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/location/RecuperarLocation.java
+++ b/src/main/java/inter/pix/location/RecuperarLocation.java
@@ -1,11 +1,11 @@
 package inter.pix.location;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.Location;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class RecuperarLocation {
         String url = URL_PIX_LOCATIONS.replace("AMBIENTE", config.getAmbiente()) + "/" + id;
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_LOCATION_READ, "Erro ao recuperar location");
         try {
-            return new ObjectMapper().readValue(json, Location.class);
+            return JsonUtils.read(json, Location.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/pix/ConsultarDevolucao.java
+++ b/src/main/java/inter/pix/pix/ConsultarDevolucao.java
@@ -1,11 +1,11 @@
 package inter.pix.pix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.DevolucaoDetalhada;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class ConsultarDevolucao {
         String url = URL_PIX_PIX.replace("AMBIENTE", config.getAmbiente()) + "/" + e2eId + "/devolucao/" + id;
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_PIX_READ, "Erro ao consultar devolução");
         try {
-            return new ObjectMapper().readValue(json, DevolucaoDetalhada.class);
+            return JsonUtils.read(json, DevolucaoDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/pix/ConsultarPix.java
+++ b/src/main/java/inter/pix/pix/ConsultarPix.java
@@ -1,11 +1,11 @@
 package inter.pix.pix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.Pix;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class ConsultarPix {
         String url = URL_PIX_PIX.replace("AMBIENTE", config.getAmbiente()) + "/" + e2eId;
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_PIX_READ, "Erro ao consultar pix");
         try {
-            return new ObjectMapper().readValue(json, Pix.class);
+            return JsonUtils.read(json, Pix.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/pix/ConsultarPixRecebidos.java
+++ b/src/main/java/inter/pix/pix/ConsultarPixRecebidos.java
@@ -1,6 +1,5 @@
 package inter.pix.pix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
@@ -8,6 +7,7 @@ import inter.pix.model.FiltroConsultarPixRecebidos;
 import inter.pix.model.PaginaPix;
 import inter.pix.model.Pix;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class ConsultarPixRecebidos {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_PIX_READ, "Erro ao consultar pix recebidos");
         try {
-            return new ObjectMapper().readValue(json, PaginaPix.class);
+            return JsonUtils.read(json, PaginaPix.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/pix/SolicitarDevolucao.java
+++ b/src/main/java/inter/pix/pix/SolicitarDevolucao.java
@@ -1,12 +1,12 @@
 package inter.pix.pix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.pix.model.RequisicaoBodyDevolucao;
 import inter.pix.model.DevolucaoDetalhada;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,9 +22,9 @@ public class SolicitarDevolucao {
         log.info("SolicitarDevolucao {} e2eId={} id={}", config.getClientId(), e2eId, id);
         String url = URL_PIX_PIX.replace("AMBIENTE", config.getAmbiente()) + "/" + e2eId + "/devolucao/" + id;
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(requisicaoBodyDevolucao);
+            String json = JsonUtils.writePretty(requisicaoBodyDevolucao);
             json = HttpUtils.callPut(config, url, ESCOPO_PIX_PIX_WRITE, "Erro ao solicitar devolução", json);
-            return new ObjectMapper().readValue(json, DevolucaoDetalhada.class);
+            return JsonUtils.read(json, DevolucaoDetalhada.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/webhook/ConsultarCallbacks.java
+++ b/src/main/java/inter/pix/webhook/ConsultarCallbacks.java
@@ -1,6 +1,5 @@
 package inter.pix.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
@@ -8,6 +7,7 @@ import inter.pix.model.FiltroBuscarCallbacks;
 import inter.pix.model.PaginaCallbacks;
 import inter.pix.model.RespostaBuscarCallbacks;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -50,7 +50,7 @@ public class ConsultarCallbacks {
                 + addfilters(filtro);
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_WEBHOOK_READ, "Erro ao recuperar callbacks");
         try {
-            return new ObjectMapper().readValue(json, PaginaCallbacks.class);
+            return JsonUtils.read(json, PaginaCallbacks.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/pix/webhook/CriarWebhook.java
+++ b/src/main/java/inter/pix/webhook/CriarWebhook.java
@@ -1,11 +1,11 @@
 package inter.pix.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.CriarWebhookRequest;
 import inter.model.Erro;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class CriarWebhook {
         String url = URL_PIX_WEBHOOK.replace("AMBIENTE", config.getAmbiente()) + "/" + chave;
         CriarWebhookRequest request = CriarWebhookRequest.builder().webhookUrl(webhookUrl).build();
         try {
-            String json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(request);
+            String json = JsonUtils.writePretty(request);
             HttpUtils.callPut(config, url, ESCOPO_PIX_WEBHOOK_WRITE, "Erro ao criar webhook", json);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);

--- a/src/main/java/inter/pix/webhook/ObterWebhook.java
+++ b/src/main/java/inter/pix/webhook/ObterWebhook.java
@@ -1,11 +1,11 @@
 package inter.pix.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.SdkException;
 import inter.model.Config;
 import inter.model.Erro;
 import inter.model.Webhook;
 import inter.utils.HttpUtils;
+import inter.utils.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class ObterWebhook {
         String url = URL_PIX_WEBHOOK.replace("AMBIENTE", config.getAmbiente()) + "/" + chave;
         String json = HttpUtils.callGet(config, url, ESCOPO_PIX_WEBHOOK_READ, "Erro ao obter webhook");
         try {
-            return new ObjectMapper().readValue(json, Webhook.class);
+            return JsonUtils.read(json, Webhook.class);
         } catch (IOException ioException) {
             log.error(GENERIC_EXCEPTION_MESSAGE, ioException);
             throw new SdkException(

--- a/src/main/java/inter/utils/HttpUtils.java
+++ b/src/main/java/inter/utils/HttpUtils.java
@@ -1,7 +1,6 @@
 package inter.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import inter.exceptions.CertificadoException;
 import inter.exceptions.ClientException;
 import inter.exceptions.SdkException;
@@ -158,7 +157,7 @@ public class HttpUtils {
         if (response.getStatusLine().getStatusCode() >= SERVER_ERROR_BASE) {
             HttpEntity body = response.getEntity();
             String json = EntityUtils.toString(body, StandardCharsets.UTF_8);
-            ServerException e = new ServerException(message, json.isEmpty() ? Erro.builder().title(response.getStatusLine().toString()).build() : new ObjectMapper().readValue(json, Erro.class));
+            ServerException e = new ServerException(message, json.isEmpty() ? Erro.builder().title(response.getStatusLine().toString()).build() : JsonUtils.read(json, Erro.class));
             logAndThrowException(e);
         } else if (response.getStatusLine().getStatusCode() >= CLIENT_ERROR_BASE) {
             if (response.getStatusLine().getStatusCode() == TOO_MANY_REQUESTS && rateLimitControl) {
@@ -168,7 +167,7 @@ public class HttpUtils {
             String json = EntityUtils.toString(body, StandardCharsets.UTF_8);
             Erro erro;
             try {
-                erro = json.isEmpty() ? Erro.builder().title(response.getStatusLine().toString()).build() : new ObjectMapper().readValue(json, Erro.class);
+                erro = json.isEmpty() ? Erro.builder().title(response.getStatusLine().toString()).build() : JsonUtils.read(json, Erro.class);
             } catch (JsonProcessingException e) {
                 erro = Erro.builder().title(response.getStatusLine().toString()).build();
             }

--- a/src/main/java/inter/utils/JsonUtils.java
+++ b/src/main/java/inter/utils/JsonUtils.java
@@ -1,0 +1,61 @@
+package inter.utils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+public final class JsonUtils {
+
+  private JsonUtils() {}
+
+  public static ObjectMapper getObjectMapper() {
+    ObjectMapper mapper =
+        JsonMapper.builder()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true)
+
+            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+
+            .configure(SerializationFeature.CLOSE_CLOSEABLE, true)
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+            .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+            .build();
+
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    return mapper;
+  }
+
+  public static <T> T read(String json, Class<T> cls) throws JsonProcessingException {
+    ObjectMapper mapper = getObjectMapper();
+    return mapper.readValue(json, cls);
+  }
+
+  public static <T> T read(String json, final TypeReference<T> type)
+      throws JsonProcessingException {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    return mapper.readValue(json, type);
+  }
+
+  public static String write(Object object) throws JsonProcessingException {
+    ObjectMapper mapper = getObjectMapper();
+    return mapper.writeValueAsString(object);
+  }
+
+  public static String writePretty(Object object) throws JsonProcessingException {
+    ObjectMapper mapper = getObjectMapper();
+    return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+  }
+
+}


### PR DESCRIPTION
Cada serviço instancia um ObjectMapper quando necessita serializar ou desserializar um objeto no formato JSON. Este isolamento dificulta a padronização do código que obriga ao desenvolvedor a adicionar anotações em cada classe que será manipulada pelo ObjectMapper para omitir valores nulos, por exemplo. Além de possibilitar inserir bugs pois um objeto pode ser serializado em formato diferente do esperado.

Esta PR cria um Singleton que centraliza a construção do ObjectMapper, padroniza as configurações e diminui o código digitado pois ele encapsula os principais métodos usados para serialização e desserialização de objetos no formato JSON.

